### PR TITLE
🔇 chore(App.jsx): comment out unused 'location' variable to clean up …

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import Preloader from "./components/UIElements/Preloader/Preloader";
 import "./styles/Globals.scss";
 
 const App = () => {
+  // const location = useLocation();
   return (
     <Suspense fallback={<Preloader />}>
       <Router>


### PR DESCRIPTION
…code

The 'location' variable was commented out because it was declared but not used anywhere in the code. This change helps to keep the code clean and avoid unnecessary variable declarations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Prepared for future enhancements by setting up the `useLocation` hook in the `App` component (currently commented out).

- **Style**
  - No visible style changes to end-users in this release.

- **Documentation**
  - Inline comments added for potential use of `location` in the app's routing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->